### PR TITLE
Added sequencing center for Moguel2021

### DIFF
--- a/assets/enums/sequencing_center.json
+++ b/assets/enums/sequencing_center.json
@@ -36,6 +36,7 @@
         "Robert Koch Institute",
         "Harvard University",
         "Max Planck Institute for Developmental Biology",
+        "Genome Services Laboratory of the Unidad de Genómica Avanzada",
         "Unknown"
     ]
 }


### PR DESCRIPTION
Add sequencing center - Genome Services Laboratory of the Unidad de Genómica Avanzada - for Moguel 2021
