### PR TITLE
Add University of California, Santa Cruz

### DIFF
--- a/assets/enums/sequencing_center.json
+++ b/assets/enums/sequencing_center.json
@@ -38,6 +38,7 @@
         "LANGEBIO",
         "University of Adelaide",
         "MR DNA Lab",
+        "University of California, Santa Cruz",
         "Unknown"
     ]
 }


### PR DESCRIPTION
This PR is to add University of California, Santa Cruz to the list of sequencing centers (for libraries of #462).