### PR TITLE
Improve README for consensus sequences

### DIFF
--- a/assets/documentation/libraries/README.md
+++ b/assets/documentation/libraries/README.md
@@ -113,6 +113,9 @@ Library columns are as follows:
   data as possible (e.g. SRS, ERS, not SAMEA - see below).
 - If non-NCBI/ENA, use as close to sample-level as possible.
   - e.g. when different extracts of one sample incorrectly uploaded as samples.
+  - For GenBank consensus sequences: if the ENA/SRA sample accession ID does 
+    not exist, reuse the GenBank sequence ID for both sample and run accessions.
+    However always where possible prefer ENA/SRA secondary accession IDs.
 
 > ⚠️ Mandatory value  
 

--- a/assets/documentation/libraries/README.md
+++ b/assets/documentation/libraries/README.md
@@ -102,7 +102,7 @@ Library columns are as follows:
   - Archive: MG-RAST: should be accession code beginning with `mgp`.
     [Example](https://www.mg-rast.org/mgmain.html?mgpage=project&project=mgp13354).
 
-- Missing value: `NA`
+- Missing value: `Unknown`
 
 ## archive_sample_accession
 


### PR DESCRIPTION
This improves clarification on how to deal with GenBank consensus sequences.

Based upon differences of:

https://github.com/SPAAM-community/AncientMetagenomeDir/pull/859/ (Has no ERS code for GenBank only)
https://github.com/SPAAM-community/AncientMetagenomeDir/pull/806/ (Has ERS codes for GenBank only)

Furthermore if there is no ERS code, there is no Project accession. Therefore I had to change the 'unknown' category to make it fit the schema (`NA` is not considered by the schema to be a string, so I replace it with `Unknown`).