### PR TITLE
Add enums required for Braun2020

### DIFF
--- a/assets/enums/sample_host.json
+++ b/assets/enums/sample_host.json
@@ -29,6 +29,7 @@
         "Alouatta palliata",
         "Dioscorea sansibarensis",
         "Citrus sp.",
-        "Manihot glaziovii"
+        "Manihot glaziovii",
+        "Bovidae"
     ]
 }

--- a/assets/enums/singlegenome_species.json
+++ b/assets/enums/singlegenome_species.json
@@ -42,6 +42,7 @@
         "Klebsiella pneumoniae",
         "Acinetobacter nosocomialis",
         "Acinetobacter junii",
-        "Olsenella sp. oral taxon 807"
+        "Olsenella sp. oral taxon 807",
+        "Bacillus anthracis"
     ]
 }


### PR DESCRIPTION
Adds Bovid (historical blood stain, no more info) and also Bacillus anthricis