### PR TITLE
Add info for cases such as Bozzi20224

### DIFF
--- a/assets/documentation/libraries/README.md
+++ b/assets/documentation/libraries/README.md
@@ -42,7 +42,7 @@ Library columns are as follows:
     Muhlemann2018c (second duplicate) etc.
 - If the authors re-used data from previously published studies that have not
   been added to AncientMetagenomeDir, please use the project name of the current
-  study for all samples.
+  study where metagenomics or microbial genomic analysis has been performed for all samples.
 
 > ⚠️ [MIxS v5](https://gensc.org/mixs/) compliant field
 

--- a/assets/documentation/libraries/README.md
+++ b/assets/documentation/libraries/README.md
@@ -42,7 +42,8 @@ Library columns are as follows:
     Muhlemann2018c (second duplicate) etc.
 - If the authors re-used data from previously published studies that have not
   been added to AncientMetagenomeDir, please use the project name of the current
-  study where metagenomics or microbial genomic analysis has been performed for all samples.
+  study where metagenomics or microbial genomic analysis has been performed for
+  all samples.
 
 > ⚠️ [MIxS v5](https://gensc.org/mixs/) compliant field
 

--- a/assets/documentation/libraries/README.md
+++ b/assets/documentation/libraries/README.md
@@ -40,6 +40,9 @@ Library columns are as follows:
     'second' key added.
   - e.g. Muhlemann2018 (original), Muhlemann2018b (first duplicate),
     Muhlemann2018c (second duplicate) etc.
+- If the authors re-used data from previously published studies that have not
+  been added to AncientMetagenomeDir, please use the project name of the current
+  study for all samples.
 
 > ⚠️ [MIxS v5](https://gensc.org/mixs/) compliant field
 

--- a/assets/documentation/samples/README.md
+++ b/assets/documentation/samples/README.md
@@ -41,7 +41,8 @@ Sample columns are as follows:
     Muhlemann2018c (second duplicate) etc.
 - If the authors re-used data from previously published studies that have not
   been added to AncientMetagenomeDir, please use the project name of the current
-  study for all samples.
+  study where metagenomics or microbial genomic analysis has been performed for
+  all samples.
 
 > ⚠️ [MIxS v5](https://gensc.org/mixs/) compliant field
 

--- a/assets/documentation/samples/README.md
+++ b/assets/documentation/samples/README.md
@@ -39,6 +39,9 @@ Sample columns are as follows:
     'second' key added.
   - e.g. Muhlemann2018 (original), Muhlemann2018b (first duplicate),
     Muhlemann2018c (second duplicate) etc.
+- If the authors re-used data from previously published studies that have not
+  been added to AncientMetagenomeDir, please use the project name of the current
+  study for all samples.
 
 > ⚠️ [MIxS v5](https://gensc.org/mixs/) compliant field
 


### PR DESCRIPTION
Adds the clarification to the README on how to select the project name when a study re-used previously published data that has not been added to AMDir yet.