### PR TITLE
Add novel bacterial species identified by Guinet2025

### DIFF
--- a/assets/enums/singlegenome_species.json
+++ b/assets/enums/singlegenome_species.json
@@ -59,6 +59,10 @@
         "Erysipelothrix rhusiopathiae",
         "Monkeypox virus",
         "Plasmodium malariae",
-        "Human gammaherpesvirus 4"
+        "Human gammaherpesvirus 4",
+        "Erysipelothrix sp.",
+        "Actinobacillus sp.",
+        "Streptococcus sp.",
+        "Pasteurella sp."
     ]
 }


### PR DESCRIPTION
Required to add the single genome information of Guinet 2025 (#1585).
