### PR TITLE
Update library_polymerase.json

### DIFF
--- a/assets/enums/library_polymerase.json
+++ b/assets/enums/library_polymerase.json
@@ -19,6 +19,7 @@
     "HGS Taq Diamond",
     "HotStarTaq DNA",
     "Bst DNA Polymerase, Large Fragment",
+    "LongAmp Taq DNA",
     "Unknown"
   ]
 }


### PR DESCRIPTION
added LongAmp Taq DNA to the polymerase enums list

# Pull Request

This PR is for an addition to the library_polymerase in the library enums. 

This is connected to the #1553 Urban2025 update (and my incomplete #1690 pull request). 

The paper uses a polymerase for the initial indexing PRC which is not mentioned in the enums. The polymerase used is "LongAmp Taq DNA" from the LongAmp® Taq 2X Master Mix, which uses a mix of two polymerases (Taq DNA Polymerase, which is not proofreading, and Deep Vent DNA Polymerase which is proofreading).

the paper can be found here: 
https://link.springer.com/article/10.1186/s12915-025-02282-z

information about the polymerase used is here: 
https://www.neb.com/en/products/m0287-longamp-taq-2x-master-mix
