### PR TITLE
Allow SHCal04 as a C14 calibration curve

### DIFF
--- a/assets/enums/c14_calibration_curve.json
+++ b/assets/enums/c14_calibration_curve.json
@@ -5,6 +5,7 @@
         "IntCal13",
         "IntCal20", 
         "CalPal2007_HULU",
+        "SHCal04",
         "SHCal13",
         "SHCal20", 
         "Marine20",


### PR DESCRIPTION
Add SHCal04 to allowed C14 calibration curves to address issue in #1763.